### PR TITLE
update embedded hal to v1.0 rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+**Breaking changes!**
+- Update to embedded-hal v1.0.0 rc2
+
 # 1.2.0
 **Breaking changes!**
 - Updated to embedded hal 1.0.0-alpha.9 (@MajorArkwolf)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,17 +26,17 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "1.0.0-alpha.9"
+version = "1.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129b101ddfee640565f7c07b301a31d95aa21e5acef21a491c307139f5fa4c91"
+checksum = "3e57ec6ad0bc8eb967cf9c9f144177f5e8f2f6f02dad0b8b683f9f05f6b22def"
 
 [[package]]
 name = "embedded-hal-nb"
-version = "1.0.0-alpha.1"
+version = "1.0.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0760ec0a3bf76859d5e33f39542af103f157d5b2ecfb00ace56dd461472e3a"
+checksum = "67c4325112d63ff5991e2841960a1320516c33ff7237e924eaab0772b1123703"
 dependencies = [
- "embedded-hal 1.0.0-alpha.9",
+ "embedded-hal 1.0.0-rc.2",
  "nb 1.0.0",
 ]
 
@@ -120,12 +120,10 @@ dependencies = [
 name = "pca9535"
 version = "1.2.0"
 dependencies = [
- "embedded-hal 1.0.0-alpha.9",
+ "embedded-hal 1.0.0-rc.2",
  "lazy_static",
- "pca9535",
  "rppal",
  "serial_test",
- "shared-bus",
 ]
 
 [[package]]
@@ -181,12 +179,12 @@ dependencies = [
 
 [[package]]
 name = "rppal"
-version = "0.14.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612e1a22e21f08a246657c6433fe52b773ae43d07c9ef88ccfc433cc8683caba"
+checksum = "23aff72e177b0e0b0e0801bbe9f41de2abafd396dfb69af9c602ffba8c2091b3"
 dependencies = [
  "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-alpha.9",
+ "embedded-hal 1.0.0-rc.2",
  "embedded-hal-nb",
  "libc",
  "nb 0.1.3",
@@ -228,18 +226,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
-]
-
-[[package]]
-name = "shared-bus"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f8438a40b91c8b9531c664e9680c55b92bd78cd6809a8b45b4512b1e5765f2"
-dependencies = [
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-alpha.9",
- "nb 0.1.3",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,8 +122,10 @@ version = "1.2.0"
 dependencies = [
  "embedded-hal 1.0.0-rc.2",
  "lazy_static",
+ "pca9535",
  "rppal",
  "serial_test",
+ "shared-bus",
 ]
 
 [[package]]
@@ -226,6 +228,17 @@ dependencies = [
  "quote",
  "rustversion",
  "syn",
+]
+
+[[package]]
+name = "shared-bus"
+version = "0.3.1"
+source = "git+https://github.com/TeyKey1/shared-bus.git?rev=87af545#87af5451a39a3e138a831f845b9dcc408a78e9eb"
+dependencies = [
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0-rc.2",
+ "nb 1.0.0",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ hal = { version = "=1.0.0-rc.2", package = "embedded-hal" }
 
 [dev-dependencies]
 lazy_static = "1.4"
-#pca9535 = { path = ".", features = ["std"] }
+pca9535 = { path = ".", features = ["std"] }
 rppal = { version = "0.16.0", features = ["hal"] }
 serial_test = "0.6"
-#shared-bus = { version = "0.2.5", features = ["std", "eh-alpha"] }
+shared-bus = { git = "https://github.com/TeyKey1/shared-bus.git", rev="87af545", features = ["std", "eh-alpha"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ license = "MIT"
 std = []
 
 [dependencies]
-hal = { version = "=1.0.0-alpha.9", package = "embedded-hal" }
+hal = { version = "=1.0.0-rc.2", package = "embedded-hal" }
 
 [dev-dependencies]
 lazy_static = "1.4"
-pca9535 = { path = ".", features = ["std"] }
-rppal = { version = "0.14.1", features = ["hal"] }
+#pca9535 = { path = ".", features = ["std"] }
+rppal = { version = "0.16.0", features = ["hal"] }
 serial_test = "0.6"
-shared-bus = { version = "0.2.5", features = ["std", "eh-alpha"] }
+#shared-bus = { version = "0.2.5", features = ["std", "eh-alpha"] }

--- a/src/expander/mod.rs
+++ b/src/expander/mod.rs
@@ -74,6 +74,12 @@ where
     WriteReadError(ERR),
 }
 
+impl<ERR: Debug> hal::digital::Error for ExpanderError<ERR> {
+    fn kind(&self) -> hal::digital::ErrorKind {
+        hal::digital::ErrorKind::Other
+    }
+}
+
 #[cfg(feature = "std")]
 impl<T> std::fmt::Display for ExpanderError<T>
 where


### PR DESCRIPTION
The release candidates of embedded-hal should only contain minimal changes until the full release of 1.0 It's likely that pca9535 does not need any further adjustments once 1.0 is released.

fixes #2 
